### PR TITLE
Fix StrictMode import to resolve Vercel build error

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { BudgetProvider } from './context/BudgetContext.jsx';
 import Dashboard from './components/Dashboard.jsx';
 import Login from './components/Login.jsx';

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './styles/global.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );


### PR DESCRIPTION
## Summary
- import React's StrictMode as a named export to avoid duplicate React declarations during builds
- render the app inside the StrictMode component without relying on the default React identifier

## Testing
- npm run build *(fails: npm registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de4c0a3f8c832c9f5c69f4093ff12b